### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lmallez/anki-slot-machine/security/code-scanning/1](https://github.com/lmallez/anki-slot-machine/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `quality`) unless overridden. For this CI workflow, `contents: read` is the minimal and appropriate permission for `actions/checkout` and read-only validation tasks. This resolves the CodeQL finding without changing functionality.

Concretely, insert:

```yml
permissions:
  contents: read
```

between the `on:` trigger section and the `jobs:` section.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
